### PR TITLE
Add staking vault to draw manager

### DIFF
--- a/src/DrawManager.sol
+++ b/src/DrawManager.sol
@@ -306,7 +306,7 @@ contract DrawManager {
 
     _reward(_lastStartDrawAuction.recipient, rewards[0]);
     _reward(_rewardRecipient, rewards[1]);
-    if (stakingVault != address(0)) {
+    if (stakingVault != address(0) && remainingReserve != 0) {
       _reward(address(this), remainingReserve);
       prizePool.withdrawRewards(address(prizePool), remainingReserve);
       prizePool.contributePrizeTokens(stakingVault, remainingReserve);

--- a/src/DrawManager.sol
+++ b/src/DrawManager.sol
@@ -98,8 +98,8 @@ contract DrawManager {
   /// @notice The maximum total rewards for both auctions for a single draw
   uint256 public immutable maxRewards;
 
-  /// @notice The address of the staking vault to contribute remaining reserve on behalf of
-  address public immutable stakingVault;
+  /// @notice The address of a vault to contribute remaining reserve on behalf of
+  address public immutable vaultBeneficiary;
 
   /// @notice The last Start Draw auction result
   StartDrawAuction internal _lastStartDrawAuction;
@@ -154,7 +154,7 @@ contract DrawManager {
   /// @param _firstStartDrawTargetFraction The expected reward fraction for the first start rng auction (to help fine-tune the system)
   /// @param _firstFinishDrawTargetFraction The expected reward fraction for the first finish draw auction (to help fine-tune the system)
   /// @param _maxRewards The maximum amount of rewards that can be allocated to the auction
-  /// @param _stakingVault The address of the staking vault to contribute remaining reserve on behalf of
+  /// @param _vaultBeneficiary The address of a vault to contribute remaining reserve on behalf of
   constructor(
     PrizePool _prizePool,
     IRng _rng,
@@ -163,7 +163,7 @@ contract DrawManager {
     UD2x18 _firstStartDrawTargetFraction,
     UD2x18 _firstFinishDrawTargetFraction,
     uint256 _maxRewards,
-    address _stakingVault
+    address _vaultBeneficiary
   ) {
     if (_auctionTargetTime > _auctionDuration) {
       revert AuctionTargetTimeExceedsDuration(
@@ -182,7 +182,7 @@ contract DrawManager {
 
     lastStartDrawFraction = _firstStartDrawTargetFraction;
     lastFinishDrawFraction = _firstFinishDrawTargetFraction;
-    stakingVault = _stakingVault;
+    vaultBeneficiary = _vaultBeneficiary;
 
     auctionDuration = _auctionDuration;
     auctionTargetTime = _auctionTargetTime;
@@ -306,10 +306,10 @@ contract DrawManager {
 
     _reward(_lastStartDrawAuction.recipient, rewards[0]);
     _reward(_rewardRecipient, rewards[1]);
-    if (stakingVault != address(0) && remainingReserve != 0) {
+    if (vaultBeneficiary != address(0) && remainingReserve != 0) {
       _reward(address(this), remainingReserve);
       prizePool.withdrawRewards(address(prizePool), remainingReserve);
-      prizePool.contributePrizeTokens(stakingVault, remainingReserve);
+      prizePool.contributePrizeTokens(vaultBeneficiary, remainingReserve);
     }
 
     return drawId;

--- a/test/DrawManager.t.sol
+++ b/test/DrawManager.t.sol
@@ -247,6 +247,8 @@ contract DrawManagerTest is Test {
         vm.warp(1 days + auctionTargetTime);
 
         mockFinishDraw(0x1234);
+        uint256 remaining = 1e18 - 199999999999999994 - 28;
+        vm.mockCall(address(prizePool), abi.encodeWithSelector(prizePool.contributePrizeTokens.selector, stakingVault, remaining), abi.encode(remaining));
         vm.expectEmit(true, true, true, true);
         emit DrawFinished(
             address(this),
@@ -254,7 +256,7 @@ contract DrawManagerTest is Test {
             1,
             auctionTargetTime,
             199999999999999994,
-            1e18 - 199999999999999994 - 28
+            remaining
         );
         drawManager.finishDraw(bob);
     }

--- a/test/DrawManager.t.sol
+++ b/test/DrawManager.t.sol
@@ -53,7 +53,7 @@ contract DrawManagerTest is Test {
     UD2x18 lastStartDrawFraction = UD2x18.wrap(0.1e18);
     UD2x18 lastFinishDrawFraction = UD2x18.wrap(0.2e18);
     uint256 maxRewards = 10e18;
-    address stakingVault = address(this);
+    address vaultBeneficiary = address(this);
 
     address bob = makeAddr("bob");
     address alice = makeAddr("alice");
@@ -74,7 +74,7 @@ contract DrawManagerTest is Test {
         assertEq(drawManager.auctionDuration(), auctionDuration, "auction duration");
         assertEq(drawManager.auctionTargetTime(), auctionTargetTime, "auction target time");
         assertEq(drawManager.maxRewards(), maxRewards, "max rewards");
-        assertEq(drawManager.stakingVault(), stakingVault, "staking vault");
+        assertEq(drawManager.vaultBeneficiary(), vaultBeneficiary, "staking vault");
         assertEq(drawManager.lastStartDrawFraction().unwrap(), lastStartDrawFraction.unwrap(), "last start rng request fraction");
         assertEq(drawManager.lastFinishDrawFraction().unwrap(), lastFinishDrawFraction.unwrap(), "last award draw fraction");
     }
@@ -248,7 +248,7 @@ contract DrawManagerTest is Test {
 
         mockFinishDraw(0x1234);
         uint256 remaining = 1e18 - 199999999999999994 - 28;
-        vm.mockCall(address(prizePool), abi.encodeWithSelector(prizePool.contributePrizeTokens.selector, stakingVault, remaining), abi.encode(remaining));
+        vm.mockCall(address(prizePool), abi.encodeWithSelector(prizePool.contributePrizeTokens.selector, vaultBeneficiary, remaining), abi.encode(remaining));
         vm.expectEmit(true, true, true, true);
         emit DrawFinished(
             address(this),
@@ -392,7 +392,7 @@ contract DrawManagerTest is Test {
             lastStartDrawFraction,
             lastFinishDrawFraction,
             maxRewards,
-            stakingVault
+            vaultBeneficiary
         );
     }
 }

--- a/test/DrawManager.t.sol
+++ b/test/DrawManager.t.sol
@@ -53,7 +53,7 @@ contract DrawManagerTest is Test {
     UD2x18 lastStartDrawFraction = UD2x18.wrap(0.1e18);
     UD2x18 lastFinishDrawFraction = UD2x18.wrap(0.2e18);
     uint256 maxRewards = 10e18;
-    address remainingRewardsRecipient = address(this);
+    address stakingVault = address(this);
 
     address bob = makeAddr("bob");
     address alice = makeAddr("alice");
@@ -74,7 +74,7 @@ contract DrawManagerTest is Test {
         assertEq(drawManager.auctionDuration(), auctionDuration, "auction duration");
         assertEq(drawManager.auctionTargetTime(), auctionTargetTime, "auction target time");
         assertEq(drawManager.maxRewards(), maxRewards, "max rewards");
-        assertEq(drawManager.remainingRewardsRecipient(), remainingRewardsRecipient, "remaining rewards recipient");
+        assertEq(drawManager.stakingVault(), stakingVault, "staking vault");
         assertEq(drawManager.lastStartDrawFraction().unwrap(), lastStartDrawFraction.unwrap(), "last start rng request fraction");
         assertEq(drawManager.lastFinishDrawFraction().unwrap(), lastFinishDrawFraction.unwrap(), "last award draw fraction");
     }
@@ -390,7 +390,7 @@ contract DrawManagerTest is Test {
             lastStartDrawFraction,
             lastFinishDrawFraction,
             maxRewards,
-            remainingRewardsRecipient
+            stakingVault
         );
     }
 }


### PR DESCRIPTION
The draw manager takes all remaining reserve in the prize pool and contributes it on behalf of a staking vault (for example: a POOL vault)