### PR TITLE
Prevent startDraw if prize pool is shutdown

### DIFF
--- a/src/DrawManager.sol
+++ b/src/DrawManager.sol
@@ -280,13 +280,17 @@ contract DrawManager {
     StartDrawAuction memory lastStartDrawAuction = getLastStartDrawAuction();
     return (
       (
-        // if we're on a new draw
-        drawId != lastStartDrawAuction.drawId ||
-        // OR we're on the same draw, but the request has failed and we haven't retried too many times
-        (rng.isRequestFailed(lastStartDrawAuction.rngRequestId) && _startDrawAuctions.length <= maxRetries)
-      ) && // we haven't started it, or we have and the request has failed
-      block.timestamp >= drawClosesAt && // the draw has closed
-      _computeElapsedTime(drawClosesAt, block.timestamp) <= auctionDuration // the draw hasn't expired
+        drawId != lastStartDrawAuction.drawId ? (
+          // if we're on a new draw
+          _computeElapsedTime(drawClosesAt, block.timestamp) <= auctionDuration
+        ) : (
+          // OR we're on the same draw, but the request has failed and we haven't retried too many times
+          rng.isRequestFailed(lastStartDrawAuction.rngRequestId) &&
+          _startDrawAuctions.length <= maxRetries &&
+          _computeElapsedTime(lastStartDrawAuction.closedAt, block.timestamp) <= auctionDuration
+        )
+      ) &&
+      block.timestamp >= drawClosesAt // the draw has closed
     );
   }
 


### PR DESCRIPTION
### ⚠️ Commits on top of #15 to prevent merge conflicts ⚠️

(diff between this and #15 can be viewed [here](https://github.com/GenerationSoftware/pt-v5-draw-manager/compare/gen-1774-129-canstartdraw-uses-different-logic-than-startdraw...gen-1766-26-start-draw-can-be-called-after-the-prize-pool-has))

This PR modifies the `canStartDraw` and `startDraw` functions to prevent the start of a new draw when the prize pool is shutdown.