### PR TITLE
cap total rewards at 100% of available rewards

### DIFF
--- a/src/DrawManager.sol
+++ b/src/DrawManager.sol
@@ -257,7 +257,7 @@ contract DrawManager {
       rngRequestId: _rngRequestId
     }));
 
-    (uint[] memory rewards,) = _computeStartDrawRewards(closesAt, _computeAvailableRewards());
+    (uint[] memory rewards,,) = _computeStartDrawRewards(closesAt, _computeAvailableRewards());
 
     emit DrawStarted(
       msg.sender,
@@ -296,15 +296,20 @@ contract DrawManager {
     if (!canStartDraw()) {
       return 0;
     }
-    uint256 auctionOpenedAt;
     StartDrawAuction memory lastRequest = getLastStartDrawAuction();
-    if (lastRequest.drawId != prizePool.getDrawIdToAward()) {
-      // if it's a new draw
-      auctionOpenedAt = prizePool.drawClosesAt(prizePool.getDrawIdToAward());
-    } else {
-      auctionOpenedAt = lastRequest.closedAt;
-    }
-    (uint256 reward,) = _computeStartDrawReward(auctionOpenedAt, block.timestamp, _computeAvailableRewards());
+    uint24 drawIdToAward = prizePool.getDrawIdToAward();
+    uint48 drawClosedAt = prizePool.drawClosesAt(drawIdToAward);
+    uint256 availableRewards =_computeAvailableRewards();
+    (,, UD2x18 fractionalRewardsLeft) = _computeStartDrawRewards(
+      drawClosedAt,
+      availableRewards
+    );
+    (uint256 reward,) = _computeStartDrawReward(
+      lastRequest.drawId != drawIdToAward ? drawClosedAt : lastRequest.closedAt,
+      block.timestamp,
+      availableRewards,
+      fractionalRewardsLeft
+    );
     return reward;
   }
 
@@ -331,14 +336,15 @@ contract DrawManager {
     }
     
     uint256 availableRewards = _computeAvailableRewards();
-    (uint256[] memory startDrawRewards, UD2x18[] memory startDrawFractions) = _computeStartDrawRewards(
+    (uint256[] memory startDrawRewards, UD2x18[] memory startDrawFractions, UD2x18 maxFinishDrawFractionalReward) = _computeStartDrawRewards(
       prizePool.drawClosesAt(startDrawAuction.drawId),
       availableRewards
     );
     (uint256 _finishDrawReward, UD2x18 finishFraction) = _computeFinishDrawReward(
       startDrawAuction.closedAt,
       block.timestamp,
-      availableRewards
+      availableRewards,
+      maxFinishDrawFractionalReward
     );
     uint256 randomNumber = rng.randomNumber(startDrawAuction.rngRequestId);
     uint24 drawId = prizePool.awardDraw(randomNumber);
@@ -388,9 +394,10 @@ contract DrawManager {
     if (!canFinishDraw()) {
       return 0;
     }
+    uint256 availableRewards = _computeAvailableRewards();
     StartDrawAuction memory startDrawAuction = getLastStartDrawAuction();
-
-    (reward,) = _computeFinishDrawReward(startDrawAuction.closedAt, block.timestamp, _computeAvailableRewards());
+    (,, UD2x18 fractionalRewardsLeft) = _computeStartDrawRewards(prizePool.drawClosesAt(prizePool.getDrawIdToAward()), availableRewards);
+    (reward,) = _computeFinishDrawReward(startDrawAuction.closedAt, block.timestamp, availableRewards, fractionalRewardsLeft);
   }
 
   /// ================= State =================
@@ -418,15 +425,18 @@ contract DrawManager {
   }
 
   /// @notice Computes what the reward and reward fraction would be for the finish draw
+  /// @dev Caps the reward such that the total rewards cannot exceed the available rewards
   /// @param _auctionOpenedAt The time at which the auction started
   /// @param _auctionClosedAt The time at which the auction closed
   /// @param _availableRewards The amount of rewards available
+  /// @param _fractionalRewardsLeft The fraction of rewards that is available
   /// @return reward The reward for the finish draw auction
   /// @return fraction The reward fraction for the finish draw auction
   function _computeFinishDrawReward(
     uint256 _auctionOpenedAt,
     uint256 _auctionClosedAt,
-    uint256 _availableRewards
+    uint256 _availableRewards,
+    UD2x18 _fractionalRewardsLeft
   ) internal view returns (uint256 reward, UD2x18 fraction) {
     fraction = RewardLib.fractionalReward(
       _computeElapsedTime(_auctionOpenedAt, _auctionClosedAt),
@@ -434,38 +444,48 @@ contract DrawManager {
       _auctionTargetTimeFraction,
       lastFinishDrawFraction
     );
+    if (fraction.unwrap() > _fractionalRewardsLeft.unwrap()) {
+      fraction = _fractionalRewardsLeft;
+    }
     reward = RewardLib.reward(fraction, _availableRewards);
   }
 
   /// @notice Computes the rewards and reward fractions for the start draw auctions
+  /// @dev Caps the reward such that the total rewards cannot exceed the available rewards
   /// @param _firstAuctionOpenedAt The time at which the first auction started
   /// @param _availableRewards The amount of rewards available
   /// @return rewards The rewards for the start draw auctions
   /// @return fractions The reward fractions for the start draw auctions
+  /// @return totalRewardFractionLeft The total fractional rewards left [0.0, 1.0] range
   function _computeStartDrawRewards(
     uint256 _firstAuctionOpenedAt,
     uint256 _availableRewards
-  ) internal view returns (uint256[] memory rewards, UD2x18[] memory fractions) {
+  ) internal view returns (uint256[] memory rewards, UD2x18[] memory fractions, UD2x18 totalRewardFractionLeft) {
     uint256 length = _startDrawAuctions.length;
     rewards = new uint256[](length);
     fractions = new UD2x18[](length);
+    totalRewardFractionLeft = UD2x18.wrap(1e18);
     uint256 previousStartTime = _firstAuctionOpenedAt;
     for (uint256 i = 0; i < length; i++) {
-      (rewards[i], fractions[i]) = _computeStartDrawReward(previousStartTime, _startDrawAuctions[i].closedAt, _availableRewards);
+      (rewards[i], fractions[i]) = _computeStartDrawReward(previousStartTime, _startDrawAuctions[i].closedAt, _availableRewards, totalRewardFractionLeft);
+      totalRewardFractionLeft = UD2x18.wrap(totalRewardFractionLeft.unwrap() - fractions[i].unwrap());
       previousStartTime = _startDrawAuctions[i].closedAt;
     }
   }
 
   /// @notice Computes the reward and reward fraction for the start draw auction
+  /// @dev Caps the reward such that it cannot exceed the remaining amount
   /// @param _auctionOpenedAt The time at which the auction started
   /// @param _auctionClosedAt The time at which the auction closed
   /// @param _availableRewards The amount of rewards available
+  /// @param _fractionalRewardsLeft The fraction of rewards that is available
   /// @return reward The reward for the start draw auction
   /// @return fraction The reward fraction for the start draw auction
   function _computeStartDrawReward(
     uint256 _auctionOpenedAt,
     uint256 _auctionClosedAt,
-    uint256 _availableRewards
+    uint256 _availableRewards,
+    UD2x18 _fractionalRewardsLeft
   ) internal view returns (uint256 reward, UD2x18 fraction) {
     fraction = RewardLib.fractionalReward(
       _computeElapsedTime(_auctionOpenedAt, _auctionClosedAt),
@@ -473,6 +493,9 @@ contract DrawManager {
       _auctionTargetTimeFraction,
       lastStartDrawFraction
     );
+    if (fraction.unwrap() > _fractionalRewardsLeft.unwrap()) {
+      fraction = _fractionalRewardsLeft;
+    }
     reward = RewardLib.reward(fraction, _availableRewards);
   }
 

--- a/test/DrawManager.t.sol
+++ b/test/DrawManager.t.sol
@@ -484,6 +484,80 @@ contract DrawManagerTest is Test {
         assertEq(auction.closedAt, block.timestamp, "started at");
         assertEq(auction.rngRequestId, 99, "rng request id");
     }
+    
+    function test_startRewardFractionsCappedAtOne() public {
+        // start and finish first draw to increase the target fractions
+        vm.warp(1 days + (auctionDuration * 3) / 4);
+        mockReserve(0, 0);
+        mockRng(98, 0x12345);
+        drawManager.startDraw(alice, 98);
+        vm.warp(block.timestamp + auctionDuration);
+        mockFinishDraw(0x12345);
+        drawManager.finishDraw(bob);
+
+        // setup next draw
+        uint256 totalAvailable = 1e18;
+        vm.warp(2 days);
+        mockReserve(1e18, 0);
+        mockRng(99, 0x1234);
+        mockDrawIdToAwardAndClosingTime(2, 2 days);
+
+        // mock failure on first start draw with over 50% rewards
+        uint256 hardCodedExpectedRewards = 614439999999999996;
+        vm.warp(block.timestamp + auctionDuration / 2);
+        assertEq(drawManager.startDrawReward(), hardCodedExpectedRewards);
+        mockRngFailure(99, true);
+        vm.expectEmit(true, true, true, true);
+        emit DrawStarted(address(this), alice, 2, auctionDuration / 2, hardCodedExpectedRewards, 99, 1);
+        drawManager.startDraw(alice, 99);
+
+        // ensure next start draw will be capped
+        vm.warp(block.timestamp + auctionDuration / 2);
+        vm.roll(block.number + 1);
+        uint256 rewardsLeftForNextStart = totalAvailable - hardCodedExpectedRewards;
+        assertEq(drawManager.startDrawReward(), rewardsLeftForNextStart);
+        mockRequestedAtBlock(100, block.number);
+        mockRngComplete(100, true);
+        mockRngFailure(100, false);
+        vm.expectEmit(true, true, true, true);
+        emit DrawStarted(address(this), alice, 2, auctionDuration / 2, rewardsLeftForNextStart, 100, 2);
+        drawManager.startDraw(alice, 100);
+    }
+
+    function test_finishRewardFractionsCappedAtOne() public {
+        uint256 totalAvailable = 1e18;
+
+        vm.warp(1 days);
+        mockReserve(1e18, 0);
+        mockRng(99, 0x1234);
+
+        // mock failure on first start draw with over 50% rewards
+        uint256 hardCodedExpectedRewards = 540999999999999998;
+        vm.warp(block.timestamp + auctionDuration * 3 / 4);
+        assertEq(drawManager.startDrawReward(), hardCodedExpectedRewards);
+        vm.expectEmit(true, true, true, true);
+        emit DrawStarted(address(this), alice, 1, auctionDuration * 3 / 4, hardCodedExpectedRewards, 99, 1);
+        drawManager.startDraw(alice, 99);
+
+        // ensure finish draw rewards are capped as well
+        uint256 rewardsLeftForNextStart = totalAvailable - hardCodedExpectedRewards;
+        vm.warp(block.timestamp + auctionDuration * 3 / 4);
+        assertEq(drawManager.finishDrawReward(), rewardsLeftForNextStart);
+        mockFinishDraw(0x1234);
+        mockAllocateRewardFromReserve(alice, hardCodedExpectedRewards);
+        mockAllocateRewardFromReserve(bob, rewardsLeftForNextStart);
+        mockReserveContribution(1e18);
+        vm.expectEmit(true, true, true, true);
+        emit DrawFinished(
+            address(this),
+            bob,
+            1,
+            auctionDuration * 3 / 4,
+            rewardsLeftForNextStart,
+            1e18
+        );
+        drawManager.finishDraw(bob);
+    }
 
     function startFirstDraw() public {
         vm.warp(1 days);


### PR DESCRIPTION
Each auction awards a fraction of the available rewards, but these reward amounts do not consider the amounts that have already been allocated. This means that if the total rewards promised ever exceed 100% of the rewards available, the draw cannot be awarded at all since the draw manager will attempt to allocate more than the available reserve.

These changes cap the reward amounts such that the total payout cannot exceed 100% of the available rewards.