### PR TITLE
ignore previous draw auctions in startDrawReward computation

### DIFF
--- a/src/DrawManager.sol
+++ b/src/DrawManager.sol
@@ -309,10 +309,14 @@ contract DrawManager {
     uint24 drawIdToAward = prizePool.getDrawIdToAward();
     uint48 drawClosedAt = prizePool.drawClosesAt(drawIdToAward);
     uint256 availableRewards =_computeAvailableRewards();
-    (,, UD2x18 fractionalRewardsLeft) = _computeStartDrawRewards(
-      drawClosedAt,
-      availableRewards
-    );
+    UD2x18 fractionalRewardsLeft = UD2x18.wrap(1e18);
+    if (lastRequest.drawId == drawIdToAward) {
+      // deduct the rewards that have already been allocated in auctions for this draw
+      (,, fractionalRewardsLeft) = _computeStartDrawRewards(
+        drawClosedAt,
+        availableRewards
+      );
+    }
     (uint256 reward,) = _computeStartDrawReward(
       lastRequest.drawId != drawIdToAward ? drawClosedAt : lastRequest.closedAt,
       block.timestamp,


### PR DESCRIPTION
# This PR applies a fix for the logic added in #17. Please refer to #17 for full context of the fix.

The original fix has an issue where the `startDrawReward` calculation could return a value less than the actual reward that would be received if there were multiple start draw attempts in the *previous* draw. This fixes that bug by ignoring the auction results from the previous draw.